### PR TITLE
Dry run signal approval flow test

### DIFF
--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Run the Telegram bot with background monitoring tasks.
+
+Requirements:
+- TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID in environment
+- API server running (so the bot can poll /api endpoints)
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+import sys
+
+# Ensure project root on path
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from telegram_bot.bot import TelegramBot  # noqa: E402
+from telegram_bot.handlers import setup_handlers  # noqa: E402
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    bot = TelegramBot()
+    # Setup handlers and background monitoring tasks
+    await setup_handlers(bot)
+    # Start polling
+    await bot.start()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Bot stopped by user")


### PR DESCRIPTION
Add API endpoints and a bot runner to enable dry-run testing of the Telegram signal approval flow using historical data.

This PR allows users to generate and persist signals from historical/mock data, queue them for Telegram approval, and run the bot to test the end-to-end approval flow without requiring live market access or actual trading. Risk validation is bypassed in dry-run mode to facilitate testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c777af2-2952-41ff-b858-eed729bd19e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c777af2-2952-41ff-b858-eed729bd19e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

