### PR TITLE
Generate reusable jwt token for sessions

### DIFF
--- a/api/auth_management.py
+++ b/api/auth_management.py
@@ -27,7 +27,7 @@ async def get_auth_status():
         status = AuthStatus(
             is_authenticated=service.session_token is not None and service.token_expiry is not None,
             token_expiry=service.token_expiry,
-            auth_code_expiry=service.auth_code_expiry,
+            auth_code_expiry=getattr(service, 'auth_code_expiry', None),
             last_error=None
         )
         logger.info(f"Auth status: authenticated={status.is_authenticated}")
@@ -55,7 +55,7 @@ async def update_auth_code(auth_data: AuthCodeUpdate):
         
         # Update auth code and env file
         service.auth_code = auth_code
-        service.auth_code_expiry = datetime.now() + timedelta(hours=23)  # Set new expiry
+        service._initialize_auth_expiry()
         service._update_env_auth_code(auth_code)
         
         # Clear existing session to force re-authentication


### PR DESCRIPTION
Implement daily JWT caching for IIFL API authentication to avoid repeated `getusersession` calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-6323658f-f760-444b-ada9-19c3c0311162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6323658f-f760-444b-ada9-19c3c0311162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

