### PR TITLE
Update to new iifl api endpoint

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     iifl_client_id: str = Field(..., env="IIFL_CLIENT_ID")
     iifl_auth_code: str = Field(..., env="IIFL_AUTH_CODE")
     iifl_app_secret: str = Field(..., env="IIFL_APP_SECRET")
-    iifl_base_url: str = Field("https://ttblaze.iifl.com/apimarketdata", env="IIFL_BASE_URL")
+    iifl_base_url: str = Field("https://api.iiflcapital.com/v1", env="IIFL_BASE_URL")
     
     # Trading Configuration
     auto_trade: bool = Field(False, env="AUTO_TRADE")

--- a/setup_simple.py
+++ b/setup_simple.py
@@ -52,7 +52,7 @@ def main():
 CLIENT_ID=your_client_id
 AUTH_CODE=your_auth_code
 APP_SECRET=your_app_secret
-BASE_URL=https://ttblaze.iifl.com
+BASE_URL=https://api.iiflcapital.com/v1
 
 # Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN=your_bot_token


### PR DESCRIPTION
Remove all `ttblaze` related logic and consolidate IIFL API URLs to `https://api.iiflcapital.com/v1` because `ttblaze.iifl.com` is no longer operational.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2d9e63b-d875-41fd-bb7e-ee7a4b6042ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2d9e63b-d875-41fd-bb7e-ee7a4b6042ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

