### PR TITLE
Optimize historical data fetching loop

### DIFF
--- a/services/data_fetcher.py
+++ b/services/data_fetcher.py
@@ -216,7 +216,8 @@ class DataFetcher:
                                     break
                         standardized_data.append(standardized_item)
 
-                    self._set_cache(cache_key, standardized_data, 300)
+                    # Cache for 30 minutes to limit repeated IIFL calls
+                    self._set_cache(cache_key, standardized_data, 1800)
                     return standardized_data
             elif result:
                 error_message = result.get('message') or result.get('emsg', 'Unknown API error') if isinstance(result, dict) else 'Unknown API error'
@@ -253,8 +254,8 @@ class DataFetcher:
                                         standardized_item['date'] = standardized_item[candidate]
                                         break
                             standardized_data.append(standardized_item)
-                        # Slightly longer cache on successful fallback
-                        self._set_cache(cache_key, standardized_data, 600)
+                        # Cache for 30 minutes to limit repeated IIFL calls
+                        self._set_cache(cache_key, standardized_data, 1800)
                         return standardized_data
                 elif result2:
                     error_message2 = result2.get('message') or result2.get('emsg', 'Unknown API error') if isinstance(result2, dict) else 'Unknown API error'

--- a/services/scheduler_tasks.py
+++ b/services/scheduler_tasks.py
@@ -1,0 +1,55 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import List
+
+from models.database import AsyncSessionLocal
+from services.watchlist import WatchlistService
+from services.iifl_api import IIFLAPIService
+from services.data_fetcher import DataFetcher
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_active_symbols(session) -> List[str]:
+    try:
+        service = WatchlistService(session)
+        return await service.get_watchlist(active_only=True)
+    except Exception as e:
+        logger.warning(f"Failed to load watchlist for prefetch: {str(e)}")
+        return []
+
+
+async def prefetch_watchlist_historical_data() -> None:
+    """Prefetch historical data for active watchlist symbols.
+
+    - Runs every 30 minutes (scheduled in main.py)
+    - Limits concurrency to avoid overwhelming IIFL
+    - Fetches last ~120 days of daily candles for each symbol
+    """
+    logger.info("Starting scheduled prefetch of watchlist historical data")
+    async with AsyncSessionLocal() as session:
+        symbols = await _get_active_symbols(session)
+    if not symbols:
+        logger.info("No active watchlist symbols to prefetch")
+        return
+
+    iifl = IIFLAPIService()
+    fetcher = DataFetcher(iifl)
+
+    # Limit concurrent fetches
+    semaphore = asyncio.Semaphore(3)
+
+    async def _prefetch_symbol(sym: str):
+        async with semaphore:
+            try:
+                to_date = datetime.now().strftime("%Y-%m-%d")
+                from_date = (datetime.now() - timedelta(days=120)).strftime("%Y-%m-%d")
+                data = await fetcher.get_historical_data(sym, "1D", from_date=from_date, to_date=to_date)
+                logger.info(f"Prefetched {len(data) if data else 0} candles for {sym}")
+            except Exception as e:
+                logger.warning(f"Prefetch failed for {sym}: {str(e)}")
+
+    await asyncio.gather(*[_prefetch_symbol(s) for s in symbols])
+    logger.info("Completed scheduled prefetch of watchlist historical data")
+


### PR DESCRIPTION
Fix infinite loop in historical data fetch, add rate limiting for IIFL API calls, and schedule data prefetching every 30 minutes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae8eb53b-36ed-41a6-9ff2-97f5f81a8f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae8eb53b-36ed-41a6-9ff2-97f5f81a8f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

