### PR TITLE
Investigate report generation functionality

### DIFF
--- a/api/reports.py
+++ b/api/reports.py
@@ -27,7 +27,7 @@ async def get_report_service(db: AsyncSession = Depends(get_db)) -> ReportServic
     iifl = IIFLAPIService()
     data_fetcher = DataFetcher(iifl, db_session=db)
     pnl_service = PnLService(data_fetcher, db)
-    return ReportService(pnl_service, data_fetcher, db)
+    return ReportService(pnl_service, data_fetcher)
 
 
 @router.get("/pnl/daily")

--- a/services/report.py
+++ b/services/report.py
@@ -12,6 +12,7 @@ from reportlab.graphics.charts.linecharts import HorizontalLineChart
 from reportlab.graphics.charts.piecharts import Pie
 import io
 import base64
+import os
 
 # Optional matplotlib import
 try:
@@ -76,6 +77,11 @@ class ReportService:
             output_path = f"reports/daily_report_{report_date.strftime('%Y%m%d')}.pdf"
         
         try:
+            # Ensure output directory exists
+            output_dir = os.path.dirname(output_path)
+            if output_dir:
+                os.makedirs(output_dir, exist_ok=True)
+
             # Get report data
             report_data = await self.generate_daily_report(report_date)
             


### PR DESCRIPTION
Fix report generation by correcting `ReportService` dependency injection and ensuring the output directory exists.

The `ReportService` was incorrectly instantiated with an extra `db` argument, causing a dependency injection mismatch. Additionally, the report generation failed if the `reports/` output directory did not exist, as the code attempted to write the PDF without creating the necessary folder structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-35f86712-2b3b-43c2-90b2-08570fa5bb17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35f86712-2b3b-43c2-90b2-08570fa5bb17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

