### PR TITLE
Investigate limits api endpoint

### DIFF
--- a/services/data_fetcher.py
+++ b/services/data_fetcher.py
@@ -641,13 +641,47 @@ class DataFetcher:
             if self._margin_cache is not None:
                 return self._margin_cache
 
-            # Derive available margin via pre-order margin endpoint with minimal dummy order
+            # Primary: call provider /limits endpoint
+            try:
+                limits_resp = await self.iifl.get_limits()
+                if isinstance(limits_resp, dict):
+                    # Accept either wrapped or flat payloads
+                    payload = None
+                    if limits_resp.get("status") == "Ok" and isinstance(limits_resp.get("result"), (list, dict)):
+                        # If it's a list, take first item; else dict
+                        result_obj = limits_resp.get("result")
+                        if isinstance(result_obj, list) and result_obj:
+                            payload = result_obj[0]
+                        elif isinstance(result_obj, dict):
+                            payload = result_obj
+                    else:
+                        payload = limits_resp
+
+                    if isinstance(payload, dict):
+                        # Normalize to stable keys used by UI
+                        available = payload.get("availableMargin") or payload.get("availableCash") or payload.get("cashAvailable") or payload.get("totalCashAvailable") or payload.get("netAvailableMargin") or 0.0
+                        used = payload.get("usedMargin") or payload.get("marginUsed") or payload.get("utilizedMargin") or 0.0
+                        fund_short = payload.get("fundShort") or payload.get("fundshort") or payload.get("shortfall") or 0.0
+
+                        normalized = {
+                            "availableMargin": float(available or 0.0),
+                            "usedMargin": float(used or 0.0),
+                            "fundShort": float(fund_short or 0.0),
+                            # Maintain shape parity with fallback where callers might read these keys
+                            "preOrderMargin": 0.0,
+                            "postOrderMargin": 0.0,
+                        }
+                        self._margin_cache = normalized
+                        return normalized
+            except Exception as e:
+                logger.warning(f"/limits call failed, will try fallback: {str(e)}")
+
+            # Fallback: derive via pre-order margin endpoint with minimal dummy order
             try:
                 fallback = await self.calculate_required_margin(
                     symbol="1594", quantity=1, transaction_type="BUY", price=None, product="NORMAL", exchange="NSEEQ"
                 )
                 if fallback:
-                    # Normalize to expected keys so UI can read availableMargin/usedMargin
                     derived = {
                         "availableMargin": fallback.get("total_cash_available", 0.0),
                         "usedMargin": fallback.get("current_order_margin", 0.0),
@@ -659,7 +693,7 @@ class DataFetcher:
                     return derived
             except Exception as e:
                 logger.warning(f"Fallback preordermargin failed: {str(e)}")
-            
+
             return None
             
         except Exception as e:

--- a/services/iifl_api.py
+++ b/services/iifl_api.py
@@ -601,7 +601,13 @@ class IIFLAPIService:
         """Get user profile information"""
         return await self._make_api_request("GET", "/profile")
     
-    # Removed: get_limits (IIFL does not offer /limits). Use calculate_pre_order_margin via DataFetcher.
+    async def get_limits(self) -> Optional[Dict]:
+        """Get current account limits/margins.
+
+        Returns provider response as-is. Callers should normalize fields
+        as needed to a stable interface for UI/consumers.
+        """
+        return await self._make_api_request("GET", "/limits")
     
     # Order Management
     async def place_order(self, order_data: Dict) -> Optional[Dict]:


### PR DESCRIPTION
Prioritize `/limits` API for fetching user account limits, as it is the authoritative source for real-time funds, falling back to `/preordermargin` for compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c3bb608-e618-4278-8ea5-a0f211c61caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c3bb608-e618-4278-8ea5-a0f211c61caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

