### PR TITLE
Debug backend 404 api errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,18 +200,17 @@ if SentryAsgiMiddleware is not None:
         logger.warning(f"Failed to add Sentry middleware: {str(e)}")
 
 # Include API routers
-# Include API routers
-app.include_router(system_router, prefix="/api/system", tags=["system"])
-app.include_router(signals_router, prefix="/api/signals", tags=["signals"])
-app.include_router(portfolio_router, prefix="/api/portfolio", tags=["portfolio"])
-app.include_router(risk_router, prefix="/api/risk", tags=["risk"])
-app.include_router(reports_router, prefix="/api/reports", tags=["reports"])
-app.include_router(backtest_router, prefix="/api/backtest", tags=["backtest"])
-app.include_router(settings_router, prefix="/api/settings", tags=["settings"])
-app.include_router(events_router, prefix="/api/events", tags=["events"])
-app.include_router(auth_router, prefix="/api/auth", tags=["authentication"])
+app.include_router(system_router)
+app.include_router(signals_router)
+app.include_router(portfolio_router)
+app.include_router(risk_router)
+app.include_router(reports_router)
+app.include_router(backtest_router)
+app.include_router(settings_router)
+app.include_router(events_router)
+app.include_router(auth_router)
+app.include_router(watchlist_router)
 app.include_router(margin_router, prefix="/api/margin", tags=["margin"])
-app.include_router(watchlist_router, prefix="/api/watchlist", tags=["watchlist"])
 
 # HTTP logging middleware
 @app.middleware("http")


### PR DESCRIPTION
Remove duplicate API prefixes from router inclusions to fix 404 errors.

The `main.py` file was including routers with `prefix="/api/..."` even though the routers themselves already defined the same prefix, leading to double-prefixed routes (e.g., `/api/system/api/system/...`). This change removes the redundant prefixes from `app.include_router` calls, ensuring correct API path resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-02a1a8b7-8841-4bb5-bad4-c30997344cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02a1a8b7-8841-4bb5-bad4-c30997344cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

